### PR TITLE
Replaced mention with username

### DIFF
--- a/src/Command/InfoCommand.js
+++ b/src/Command/InfoCommand.js
@@ -144,7 +144,7 @@ module.exports = class InfoCommand {
                     name: "Analytics Bot"
                 },
                 type:      "rich",
-                title:     `Information on ${usr.mention} for the last: 30 days`,
+                title:     `Information on ${usr.username} for the last: 30 days`,
                 footer:    {
                     text: "Data is slightly delayed | All times are in UTC | " + moment.duration((new Date()) - start).milliseconds() + 'ms'
                 },


### PR DESCRIPTION
An embed can't display can't display mentions in the title (it'll get displayed as `<@!1234567890>`; [screenshot](http://i.imgur.com/uwwvZiX.png)), so I've replaced that with the friendly user name for the user.